### PR TITLE
remove(service): id property

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -16,7 +16,6 @@ use super::{
 #[derive(Debug)]
 pub struct ServiceInfo {
     pub uuid: Uuid,
-    pub id: String,
     pub name: String,
     pub priority: Priority,
 
@@ -24,13 +23,13 @@ pub struct ServiceInfo {
 }
 
 impl ServiceInfo {
-    pub fn new(id: &str, name: &str, priority: Priority) -> Self {
+    pub fn new(name: impl Into<String>, priority: Priority) -> Self {
+        let uuid = Uuid::new_v4();
         Self {
-            uuid: Uuid::new_v4(),
-            id: id.to_string(), //TODO: Drop?
-            name: name.to_string(),
+            uuid,
+            name: name.into(),
             priority,
-            status: Observable::new(Status::Stopped, format!("{}_status_change", id)),
+            status: Observable::new(Status::Stopped, format!("{}_status_change", uuid)),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -87,6 +87,7 @@ pub enum StartupError {
     #[error("Service {0} ({1}) is not stopped")]
     ServiceNotStopped(String, Uuid),
 
+    //TODO: BackgroundTaskRunning(String, Uuid, int32): Service {0} ({1}) has {2} background tasks running
     #[error("Service {0} ({1}) already has a background task running")]
     BackgroundTaskAlreadyRunning(String, Uuid),
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -23,13 +23,13 @@ pub struct DummyService {
 
 impl DummyService {
     pub fn new() -> Self {
-        let name = "dummy-service";
+        let name = "DummyService";
         let dummy_service = Self {
-            on_start: Event::new(format!("{}::on_start", name)),
-            on_stop: Event::new(format!("{}::on_stop", name)),
-            //on_task_started: Event::new(format!("{}::on_task_started", name)),
-            //on_failed: Event::new(format!("{}::on_failed", name)),
-            info: ServiceInfo::new(name, "DummyService", Priority::Essential),
+            on_start: Event::new(format!("{name}::on_start")),
+            on_stop: Event::new(format!("{name}::on_stop")),
+            //on_task_started: Event::new(format!("{name}::on_task_started")),
+            //on_failed: Event::new(format!("{name}::on_failed")),
+            info: ServiceInfo::new(name, Priority::Essential),
         };
 
         info!("DummyService created");


### PR DESCRIPTION
Remove of `id` attribute from `ServiceInfo`. `ServiceManager` now uses the `uuid` field only.