### PR TITLE
refactor(service_manager): weak reference when starting services

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, sync::Arc};
+use std::{cmp::Ordering, sync::Weak};
 
 use lum_boxtypes::{BoxedError, PinnedBoxedFuture};
 use lum_event::Observable;
@@ -58,12 +58,13 @@ impl PartialOrd for ServiceInfo {
 #[async_trait]
 pub trait Service: DowncastSync {
     fn info(&self) -> &ServiceInfo;
-    fn info_mut(&mut self) -> &mut ServiceInfo; //TODO: When lum_event offers SyncObservable, remove this
+    fn info_mut(&mut self) -> &mut ServiceInfo;
 
-    async fn start(&mut self, service_manager: Arc<ServiceManager>) -> Result<(), BoxedError>;
+    async fn start(&mut self, service_manager: Weak<ServiceManager>) -> Result<(), BoxedError>;
     async fn stop(&mut self) -> Result<(), BoxedError>;
+
+    //Can't rely on async_trait here, as it returns a non-Sync Future.
     fn fail(&mut self, _message: &str) -> PinnedBoxedFuture<()> {
-        //Can't rely on async_trait here, as it returns a non-Sync Future.
         Box::pin(async move {})
     }
 

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -88,6 +88,19 @@ impl ServiceManager {
         arc
     }
 
+    pub fn get_weak(&self) -> Weak<Self> {
+        match self.weak.get() {
+            Some(weak) => weak.clone(),
+            None => {
+                //TODO: use error_and_panic! when implemented in lum_log
+                error!(
+                    "ServiceManager's Weak self-reference was None when trying to access it. This should never happen. Panicking to prevent further undefined behavior."
+                );
+                panic!("ServiceManager's Weak self-reference was None when trying to access it.");
+            }
+        }
+    }
+
     pub async fn start_service(
         &self,
         service: Arc<Mutex<dyn Service>>,
@@ -163,6 +176,7 @@ impl ServiceManager {
 
         self.shutdown_service(&mut service_lock).await?;
 
+        //TODO: Find better way to handle this
         // Reacquiring to allow above mutable borrow
         let service_info = service_lock.info();
         let service_name = service_info.name.as_str();
@@ -208,6 +222,7 @@ impl ServiceManager {
         results
     }
 
+    //TODO: Remove comment after testing this
     /*
         I tried to do this in safe rust for 3 days, but I couldn't figure it out
         Should you come up with a way to do this in safe rust, please make a PR! :)
@@ -378,23 +393,10 @@ impl ServiceManager {
         &self,
         service: &mut MutexGuard<'_, dyn Service>,
     ) -> Result<(), StartupError> {
-        let service_manager_weak = match self.weak.get() {
-            Some(weak) => weak,
-            None => {
-                let service_info = service.info();
-                let service_name = service_info.name.as_str();
-                let service_uuid = &service.info().uuid;
-                error!(
-                    "ServiceManager's Weak self-reference was None while initializing service {service_name} ({service_uuid}). This should never happen. Did you not use a ServiceManager::new()? Panicking to prevent further undefined behavior.",
-                );
-                panic!(
-                    "ServiceManager's Weak self-reference was None while initializing service {service_name} ({service_uuid})."
-                );
-            }
-        };
+        let service_manager = self.get_weak();
 
         service.info_mut().status.set(Status::Starting).await;
-        let start = service.start(service_manager_weak.clone());
+        let start = service.start(service_manager);
         let timeout_result = timeout(Duration::from_secs(10), start).await; //TODO: Add to config instead of hardcoding duration
 
         //TODO: Merge all cases into enum with variants "Ok", "Err", and "Timeout"
@@ -492,9 +494,7 @@ impl ServiceManager {
         service.info_mut().status.set(Status::Failing).await;
         self.abort_background_tasks(service).await;
 
-        // TODO: This compiles without type annotation, but rust-analyzer complains about it :/
-        let message: String = message.into();
-
+        let message = message.into();
         service.fail(&message).await;
         service
             .info_mut()
@@ -516,20 +516,7 @@ impl ServiceManager {
             return Err(RunTaskError::ServiceNotStarted(service_name, service_uuid));
         }
 
-        //TODO: implement get_weak() in ServiceManager
-        let service_manager_weak = match self.weak.get() {
-            Some(weak) => weak.clone(),
-            None => {
-                //TODO: use error_and_panic! when implemented in lum_log
-                error!(
-                    "ServiceManager's Weak self-reference was None while running a task for service {service_name} ({service_uuid}). This should never happen. Did you not use a ServiceManager::new()? Panicking to prevent further undefined behavior."
-                );
-                panic!(
-                    "ServiceManager's Weak self-reference was None while running a task for service {service_name} ({service_uuid})."
-                );
-            }
-        };
-
+        let service_manager_weak = self.get_weak();
         let mut taskchain = Taskchain::new(task);
         //TODO: When Rust allows async closures, refactor this to have the "async" keyword after the "move" keyword
         taskchain.append(move |result| async move {
@@ -537,9 +524,10 @@ impl ServiceManager {
             let service_name = service_name.clone();
             let service_uuid = service_uuid;
 
-            let service_manager_arc = match service_manager_weak.upgrade() {
+            let service_manager = match service_manager_weak.upgrade() {
                 Some(arc) => arc,
                 None => {
+                    //TODO: use error_and_panic! when implemented in lum_log
                     error!(
                         "A task of a service {service_name} ({service_uuid}) unexpectedly ended, but cannot mark service as failed because its corresponding ServiceManager was already dropped. Panicking to prevent further undefined behavior."
                     );
@@ -549,9 +537,10 @@ impl ServiceManager {
                 }
             };
 
-            let service = match service_manager_arc.get_service_by_uuid(&service_uuid) {
+            let service = match service_manager.get_service_by_uuid(&service_uuid) {
                 Some(service) => service,
                 None => {
+                    //TODO: use error_and_panic! when implemented in lum_log
                     error!(
                         "A task of a service {service_name} ({service_uuid}) unexpectedly ended, but no service with that ID was registered in its corresponding ServiceManager. Was it removed while the task was running? Panicking to prevent further undefined behavior."
                     );
@@ -560,23 +549,23 @@ impl ServiceManager {
                     );
                 }
             };
-            let mut service_lock = service.lock().await;
 
+            let mut service_lock = service.lock().await;
             match result {
                 Ok(()) => {
                     error!(
-                        "Background task of service {service_name} ({service_uuid}) ended unexpectedly! Service will be marked as failed."
+                        "A task of service {service_name} ({service_uuid}) ended unexpectedly! Service will be marked as failed."
                     );
 
-                    service_manager_arc.fail_service(&mut service_lock, "Background task ended unexpectedly!").await;
+                    service_manager.fail_service(&mut service_lock, "Background task ended unexpectedly!").await;
                 }
 
                 Err(error) => {
                     error!(
-                        "Background task of service {service_name} ({service_uuid}) ended with error: {error}. Service will be marked as failed.",
+                        "A task of service {service_name} ({service_uuid}) ended with error: {error}. Service will be marked as failed.",
                     );
 
-                    service_manager_arc.fail_service(&mut service_lock, error.to_string()).await;
+                    service_manager.fail_service(&mut service_lock, error.to_string()).await;
                 }
             }
             Ok(())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,7 +12,7 @@ use lum_libs::{
 use lum_log::info;
 use lum_service::{
     service::{Service, ServiceInfo},
-    service_manager::{self, ServiceManager},
+    service_manager::ServiceManager,
     types::Priority,
 };
 

--- a/tests/service_framework.rs
+++ b/tests/service_framework.rs
@@ -22,4 +22,5 @@ mod tests {
     //TODO: Add test for stop_services()
     //TODO: Add tests for starting/stopping services multiple times
     //TODO: Add test for ignoring services with same UUID
+    //TODO: Add test for get_service_by_type()
 }

--- a/tests/service_framework.rs
+++ b/tests/service_framework.rs
@@ -18,4 +18,8 @@ mod tests {
         info!("Forcing an await of 0ms to allow the task to print a message");
         sleep(Duration::from_millis(0)).await;
     }
+
+    //TODO: Add test for stop_services()
+    //TODO: Add tests for starting/stopping services multiple times
+    //TODO: Add test for ignoring services with same UUID
 }


### PR DESCRIPTION
`ServiceManager` now passes a Weak reference instead of an Arc when starting a `Service`. Services are now responsible for upgrading the passed Weak to an Arc themselves, if needed. This cleans up the `ServiceManager` a bit.